### PR TITLE
tinyreq 3.0.2

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,6 +59,8 @@ Contributions are more than welcome!
 
 Thanks! :sweat_smile:
 
+
+
 [1]: https://github.com/IonicaBizau/tinyreq/issues
 
 [2]: https://github.com/IonicaBizau/code-style

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -1,7 +1,8 @@
 ## Documentation
+
 You can see below the API reference of this module.
 
-### `TinyReq(options, callback)`
+### `tinyreq(options, callback)`
 Creates http(s) requests.
 
 #### Params

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -1,7 +1,7 @@
 ## Documentation
 You can see below the API reference of this module.
 
-### `TinyReq(options, callback)`
+### `tinyreq(options, callback)`
 Creates http(s) requests.
 
 #### Params

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+
 [![tinyreq](http://i.imgur.com/FEAaOq2.png)](#)
 
 # tinyreq [![PayPal](https://img.shields.io/badge/%24-paypal-f39c12.svg)][paypal-donations] [![Version](https://img.shields.io/npm/v/tinyreq.svg)](https://www.npmjs.com/package/tinyreq) [![Downloads](https://img.shields.io/npm/dt/tinyreq.svg)](https://www.npmjs.com/package/tinyreq) [![Get help on Codementor](https://cdn.codementor.io/badges/get_help_github.svg)](https://www.codementor.io/johnnyb?utm_source=github&utm_medium=button&utm_term=johnnyb&utm_campaign=github)
@@ -10,9 +11,12 @@
 $ npm i --save tinyreq
 ```
 
+
 :bulb: **ProTip**: You can install the [cli version of this module](http://github.com/IonicaBizau/tinyreq-cli) by running `npm i -g tinyreq-cli`
 
 ## :clipboard: Example
+
+
 
 ```js
 // Dependencies
@@ -25,6 +29,7 @@ TinyReq("http://example.com/", function (err, body) {
 ```
 
 ## :memo: Documentation
+
 
 ### `tinyreq(options, callback)`
 Creates http(s) requests.
@@ -39,14 +44,17 @@ Creates http(s) requests.
 #### Return
 - **EventEmitter** An event emitter you can use for listening for the `data`, `error` and `end` events.
 
+
+
 ## :yum: How to contribute
 Have an idea? Found a bug? See [how to contribute][contributing].
 
 ## :dizzy: Where is this library used?
 If you are using this library in one of your projects, add it in this list. :sparkles:
 
+
  - [`github-colors`](https://github.com/IonicaBizau/github-colors)—GitHub colors and file extensions mapping
- - [`jsonrequest`](https://github.com/IonicaBizau/node-jsonrequest)—A tiny library for requesting and getting JSON resources.
+ - [`jsonrequest`](https://github.com/IonicaBizau/jsonrequest)—A tiny library for requesting and getting JSON resources.
  - [`tinyreq-cli`](https://github.com/IonicaBizau/tinyreq-cli#readme)—A cli tool for making http(s) requests. CLI for tinyreq.
  - [`wrabbit`](https://github.com/jillix/wrabbit) (by jillix)—Wrap scripts by providing the wrapping function.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
+
 [![tinyreq](http://i.imgur.com/FEAaOq2.png)](#)
 
-# tinyreq [![PayPal](https://img.shields.io/badge/%24-paypal-f39c12.svg)][paypal-donations] [![Version](https://img.shields.io/npm/v/tinyreq.svg)](https://www.npmjs.com/package/tinyreq) [![Downloads](https://img.shields.io/npm/dt/tinyreq.svg)](https://www.npmjs.com/package/tinyreq) [![Get help on Codementor](https://cdn.codementor.io/badges/get_help_github.svg)](https://www.codementor.io/johnnyb?utm_source=github&utm_medium=button&utm_term=johnnyb&utm_campaign=github)
+# tinyreq
+
+ [![PayPal](https://img.shields.io/badge/%24-paypal-f39c12.svg)][paypal-donations] [![AMA](https://img.shields.io/badge/ask%20me-anything-1abc9c.svg)](https://github.com/IonicaBizau/ama) [![Version](https://img.shields.io/npm/v/tinyreq.svg)](https://www.npmjs.com/package/tinyreq) [![Downloads](https://img.shields.io/npm/dt/tinyreq.svg)](https://www.npmjs.com/package/tinyreq) [![Get help on Codementor](https://cdn.codementor.io/badges/get_help_github.svg)](https://www.codementor.io/johnnyb?utm_source=github&utm_medium=button&utm_term=johnnyb&utm_campaign=github)
 
 > Tiny library for making http(s) requests.
 
@@ -10,16 +13,18 @@
 $ npm i --save tinyreq
 ```
 
+
 :bulb: **ProTip**: You can install the [cli version of this module](http://github.com/IonicaBizau/tinyreq-cli) by running `npm i -g tinyreq-cli`
 
 ## :clipboard: Example
 
+
+
 ```js
-// Dependencies
-var TinyReq = require("tinyreq");
+const tinyreq = require("tinyreq");
 
 // Make a request to example.com
-TinyReq("http://example.com/", function (err, body) {
+tinyreq("http://example.com/", (err, body) => {
     console.log(err || body);
 });
 ```
@@ -39,14 +44,18 @@ Creates http(s) requests.
 #### Return
 - **EventEmitter** An event emitter you can use for listening for the `data`, `error` and `end` events.
 
+
+
 ## :yum: How to contribute
 Have an idea? Found a bug? See [how to contribute][contributing].
 
 ## :dizzy: Where is this library used?
 If you are using this library in one of your projects, add it in this list. :sparkles:
 
+
+ - [`cheerio-req`](https://github.com/IonicaBizau/cheerio-req#readme)—An http request module sending back a Cheerio object.
  - [`github-colors`](https://github.com/IonicaBizau/github-colors)—GitHub colors and file extensions mapping
- - [`jsonrequest`](https://github.com/IonicaBizau/node-jsonrequest)—A tiny library for requesting and getting JSON resources.
+ - [`jsonrequest`](https://github.com/IonicaBizau/jsonrequest)—A tiny library for requesting and getting JSON resources.
  - [`tinyreq-cli`](https://github.com/IonicaBizau/tinyreq-cli#readme)—A cli tool for making http(s) requests. CLI for tinyreq.
  - [`wrabbit`](https://github.com/jillix/wrabbit) (by jillix)—Wrap scripts by providing the wrapping function.
 

--- a/example/index.js
+++ b/example/index.js
@@ -1,7 +1,6 @@
-// Dependencies
-var TinyReq = require("../lib");
+const tinyreq = require("../lib");
 
 // Make a request to example.com
-TinyReq("http://example.com/", function (err, body) {
+tinyreq("http://example.com/", (err, body) => {
     console.log(err || body);
 });

--- a/lib/index.js
+++ b/lib/index.js
@@ -42,7 +42,10 @@ module.exports = function tinyreq (options, callback) {
 
     // Merge options
     options = ul.deepMerge(options, defaults, {
-        method: options.data ? "POST" : "GET"
+        method: options.method
+              ? options.method
+              : options.data
+                ? "POST" : "GET"
       , headers: {}
     });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tinyreq",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "Tiny library for making http(s) requests.",
   "main": "lib/index.js",
   "directories": {
@@ -35,5 +35,16 @@
   "blah": {
     "h_img": "http://i.imgur.com/FEAaOq2.png",
     "cli": "tinyreq-cli"
-  }
+  },
+  "files": [
+    "bin/",
+    "app/",
+    "lib/",
+    "dist/",
+    "src/",
+    "resources/",
+    "menu/",
+    "cli.js",
+    "index.js"
+  ]
 }


### PR DESCRIPTION
Support all the HTTP methods.

Previously, the `POST` method was enforced in case there was request data to pipe.

/cc https://github.com/IonicaBizau/gh.js/issues/12
