### PR TITLE
Adds follow redirect capability

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,7 @@
 "use strict";
 
-const http = require("http")
-    , https = require("https")
+const http = require('follow-redirects').http,
+    https = require('follow-redirects').https,
     , ul = require("ul")
     , url = require("url")
     , queryString = require("querystring")

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,7 @@
 "use strict";
 
-const http = require('follow-redirects').http,
-    https = require('follow-redirects').https,
+const http = require('follow-redirects').http
+    , https = require('follow-redirects').https
     , ul = require("ul")
     , url = require("url")
     , queryString = require("querystring")

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   },
   "homepage": "https://github.com/IonicaBizau/tinyreq",
   "dependencies": {
+    "follow-redirects": "^0.2.0",
     "ul": "^5.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Adds an npm dependency - "follow-redirects" which replaces http, https. Works seamlessly.
