### PR TITLE
tinyreq 3.2.5

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -8,6 +8,7 @@ const http = require('follow-redirects').http
     , events = require("events")
     , EventEmitter = events.EventEmitter
     , assured = require("assured")
+    , noop = require("noop6")
     ;
 
 /**
@@ -102,7 +103,10 @@ module.exports = function tinyreq (options, callback) {
     }
 
     request.end();
-    str.then = opt_callback._.then.bind(opt_callback._);
+    str.then = fn => {
+        callback = callback || noop;
+        return opt_callback._.then(fn);
+    };
     str.catch = opt_callback._.catch.bind(opt_callback._);
     return str;
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,4 @@
-"use strict";
+"use strict"
 
 const http = require('follow-redirects').http
     , https = require('follow-redirects').https
@@ -9,7 +9,7 @@ const http = require('follow-redirects').http
     , EventEmitter = events.EventEmitter
     , assured = require("assured")
     , noop = require("noop6")
-    ;
+
 
 /**
  * tinyreq
@@ -34,7 +34,7 @@ module.exports = function tinyreq (options, callback) {
     if (typeof options === "string") {
         options = {
             url: options
-        };
+        }
     }
 
     // Merge options
@@ -45,68 +45,68 @@ module.exports = function tinyreq (options, callback) {
                 ? "POST" : "GET"
       , headers: {}
       , encoding: "utf8"
-    });
+    })
 
-    let _done = false;
+    let _done = false
 
     // Unique callback
     let opt_callback = assured((err, data, res) => {
-        if (_done) { return; }
-        _done = true;
-        if (typeof callback !== "function")  { return; }
-        callback(err, data, res);
-    });
+        if (_done) { return }
+        _done = true
+        if (typeof callback !== "function")  { return }
+        callback(err, data, res)
+    })
 
     // Handle post data
     if (options.data && options.data.constructor === Object) {
-        options.data = queryString.stringify(options.data);
+        options.data = queryString.stringify(options.data)
     }
 
     if (typeof options.data === "string") {
-        options.headers["Content-Length"] = Buffer.byteLength(options.data);
+        options.headers["Content-Length"] = Buffer.byteLength(options.data)
     }
 
-    let str = new EventEmitter();
+    let str = new EventEmitter()
 
     // Create the request
     let request = (options.protocol === "http:" ? http : https).request(options, res => {
-        options.encoding && res.setEncoding(options.encoding);
+        options.encoding && res.setEncoding(options.encoding)
         let body = []
           , bodyLength = 0
-          ;
+
 
         if (typeof callback === "function") {
             res.on("data", data => {
-                body.push(data);
-                bodyLength += data.length;
-            });
+                body.push(data)
+                bodyLength += data.length
+            })
         }
 
         res.on("data", data => {
-            str.emit("data", data);
+            str.emit("data", data)
         }).on("error", e => {
-            str.emit("error", e);
-            opt_callback(e, null, res);
+            str.emit("error", e)
+            opt_callback(e, null, res)
         }).on("end", () => {
-            str.emit("end");
-            body = options.encoding === null || options.encoding === "buffer" ? Buffer.concat(body, bodyLength) : body.join("");
-            opt_callback(null, body, res);
-        });
+            str.emit("end")
+            body = options.encoding === null || options.encoding === "buffer" ? Buffer.concat(body, bodyLength) : body.join("")
+            opt_callback(null, body, res)
+        })
     }).on("error", e => {
-        opt_callback(e, null, null);
-    });
+        opt_callback(e, null, null)
+    })
 
 
     // Handle post data
     if (options.data) {
-        request.write(options.data, options.data_encoding);
+        request.write(options.data, options.data_encoding)
     }
 
-    request.end();
+    request.end()
     str.then = fn => {
-        callback = callback || noop;
-        return opt_callback._.then(fn);
-    };
-    str.catch = opt_callback._.catch.bind(opt_callback._);
-    return str;
-};
+        callback = callback || noop
+        return opt_callback._.then(fn)
+    }
+    str.catch = opt_callback._.catch.bind(opt_callback._)
+    return str
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tinyreq",
-  "version": "3.2.4",
+  "version": "3.2.5",
   "description": "Tiny library for making http(s) requests.",
   "main": "lib/index.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "dependencies": {
     "assured": "^1.0.6",
     "follow-redirects": "^0.2.0",
+    "noop6": "^1.0.6",
     "ul": "^5.0.0"
   },
   "devDependencies": {

--- a/test/index.js
+++ b/test/index.js
@@ -1,7 +1,10 @@
 // Dependencies
 var Assert = require("assert")
   , TinyReq = require("../lib")
+  , http = require("http")
   ;
+
+mocha.setup({ timeout: 5000 });
 
 // http
 it("should support http requests", function (cb) {
@@ -9,6 +12,16 @@ it("should support http requests", function (cb) {
         Assert.equal(err, null);
         Assert.equal(!!/this domain/gi.test(body), true);
         cb();
+    });
+});
+
+// http
+it("should support promises", function (cb) {
+    TinyReq("http://example.com/").then(body => {
+        Assert.equal(!!/this domain/gi.test(body), true);
+        cb();
+    }).catch(err => {
+        cb(err);
     });
 });
 

--- a/test/index.js
+++ b/test/index.js
@@ -1,56 +1,52 @@
 // Dependencies
-var Assert = require("assert")
-  , TinyReq = require("../lib")
-  , http = require("http")
-  ;
-
-mocha.setup({ timeout: 5000 });
+const Assert = require("assert")
+    , TinyReq = require("../lib")
 
 // http
-it("should support http requests", function (cb) {
-    TinyReq("http://example.com/", function (err, body) {
-        Assert.equal(err, null);
-        Assert.equal(!!/this domain/gi.test(body), true);
-        cb();
-    });
-});
+it("should support http requests", cb => {
+    TinyReq("http://example.com/", (err, body) => {
+        Assert.equal(err, null)
+        Assert.equal(!!/this domain/gi.test(body), true)
+        cb()
+    })
+})
 
 // http
-it("should support promises", function (cb) {
+it("should support promises", cb => {
     TinyReq("http://example.com/").then(body => {
-        Assert.equal(!!/this domain/gi.test(body), true);
-        cb();
+        Assert.equal(!!/this domain/gi.test(body), true)
+        cb()
     }).catch(err => {
-        cb(err);
-    });
-});
+        cb(err)
+    })
+})
 
 // https
-it("should support https requests", function (cb) {
-    TinyReq("https://github.com", function (err, body) {
-        Assert.equal(err, null);
-        Assert.equal(!!/GitHub/gi.test(body), true);
-        cb();
-    });
-});
+it("should support https requests", cb => {
+    TinyReq("https://example.com", (err, body) => {
+        Assert.equal(err, null)
+        Assert.equal(!!/this domain/gi.test(body), true)
+        cb()
+    })
+})
 
 // Piping
-it("should support piping and no callback", function (cb) {
+it("should support piping and no callback", cb => {
 
-    var str = TinyReq("http://example.com")
+    let str = TinyReq("http://example.com")
       , body = ""
-      ;
 
-    str.on("error", function (e) {
-        cb(e);
-    });
 
-    str.on("data", function (chunk) {
-        body += chunk.toString();
-    });
+    str.on("error", e => {
+        cb(e)
+    })
 
-    str.on("end", function (chunk) {
-        Assert.equal(!!/this domain/gi.test(body), true);
-        cb();
-    });
-});
+    str.on("data", chunk => {
+        body += chunk.toString()
+    })
+
+    str.on("end", chunk => {
+        Assert.equal(!!/this domain/gi.test(body), true)
+        cb()
+    })
+})


### PR DESCRIPTION
Fix Promises support.

Tinyreq does not store the response body unless a callback is provided. This fixes the `then` functionality to enable storing the body content. Fixes #26.